### PR TITLE
disable recaptchas; add rack-attack protection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,8 @@ gem 'commonwealth-vlr-engine', github: 'boston-library/commonwealth-vlr-engine',
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 2.6', '>= 2.6.1', group: :doc
 
+gem 'rack-attack', '~> 6.8'
+
 group :development, :test do
   gem 'brakeman', require: false
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/boston-library/commonwealth-vlr-engine.git
-  revision: d5ab9562d4207687aabe2cb9b2d6be66426e2dfc
+  revision: efcf15b6bf3f810ab8e2017cf43747ec111fbf37
   branch: blacklight-8
   specs:
     commonwealth-vlr-engine (0.1.0)
@@ -404,6 +404,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.1.16)
+    rack-attack (6.8.0)
+      rack (>= 1.0, < 4)
     rack-livereload (0.6.1)
       rack (>= 3.0, < 3.2)
     rack-session (2.1.1)
@@ -657,6 +659,7 @@ DEPENDENCIES
   pg (~> 1.5, >= 1.5.9)
   propshaft
   puma (>= 5.0)
+  rack-attack (~> 6.8)
   rack-livereload (~> 0.6.1)
   rails (~> 7.2.2, >= 7.2.2.1)
   rails-controller-testing

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,5 +24,7 @@ module LmecCollections
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    config.middleware.use Rack::Attack unless Rails.env.test?
   end
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+Rack::Attack.safelist('allow from localhost') do |req|
+  # Requests are allowed if the return value is truthy
+  ['127.0.0.1', '::1'].include?(req.ip)
+end
+
+Rack::Attack.throttle('requests by ip', limit: 10, period: 1.minute) do |req|
+  req.ip if req.path.include?('/start_download/')
+end
+
+Rack::Attack.blocklist('block ips') do |req|
+  Rails.cache.read("favorites-add-item-bot:#{req.ip}")
+end
+
+# GET requests to /favorites/:id/add-item are likely bots
+# (this route doesn't exist, clicks from browser produce POST request)
+Rack::Attack.blocklist('block ips going to GET /favorites/:id/add-item') do |req|
+  if req.get? && req.path.match?(/favorites\/[0-9]*\/add-item/)
+    Rails.cache.write("favorites-add-item-bot:#{req.ip}", true, expires_in: 30.days)
+    File.write(Rails.root.join('log/favorites-add-item-bot_blocked-ips.log').to_s, "#{req.ip} - [#{DateTime.now.strftime('%Y-%m-%dT%H:%M:%S')}] - #{req.path} - #{req.user_agent.inspect}\n", mode: 'a')
+    true
+  else
+    false
+  end
+end
+
+Rack::Attack.throttled_responder = lambda do |env|
+  match_data = env['rack.attack.match_data']
+  now = match_data[:epoch_time]
+  retry_after = match_data[:period] - (now % match_data[:period])
+
+  headers = {
+    'Content-Type' => 'text/plain',
+    'Retry-After' => retry_after.to_s,
+    'RateLimit-Limit' => match_data[:limit].to_s,
+    'RateLimit-Remaining' => '0'
+  }
+
+  [429, headers, ["Retry later\n"]]
+end
+
+ActiveSupport::Notifications.subscribe('throttle.rack_attack') do |*args|
+  event = ActiveSupport::Notifications::Event.new(*args)
+
+  Rails.logger.warn '--------------------------------------------------------------'
+  Rails.logger.warn 'WARN: Client exceeded rate limit'
+  Rails.logger.warn 'Request Info:'
+  Rails.logger.warn "<Request Name: #{event.name}; ID: #{event.transaction_id}; Duration: #{event.duration} />"
+  Rails.logger.warn "< #{event.payload.inspect} />"
+  Rails.logger.warn '--------------------------------------------------------------'
+end

--- a/config/initializers/recaptcha.rb
+++ b/config/initializers/recaptcha.rb
@@ -3,4 +3,5 @@
 Recaptcha.configure do |config|
   config.site_key = ENV.fetch('RECAPTCHA_SITE_KEY') { Rails.application.credentials.dig(:recaptcha_site_key) }
   config.secret_key = ENV.fetch('RECAPTCHA_SECRET_KEY') { Rails.application.credentials.dig(:recaptcha_secret_key) }
+  config.skip_verify_env += %w[development staging production] # disable all recaptcha verification
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
 raise('The Rails environment is running in production mode!') if Rails.env.production?
+Rack::Attack.enabled = false
 
 # Uncomment the line below in case you have `--require rails_helper` in the `.rspec` file
 # that will avoid rails generators crashing because migrations haven't been run yet


### PR DESCRIPTION
Per LMEC request, and in response to ongoing issues with #3, we are disabling the recaptcha verification for downloads and form submission.

To counter the vulnerability created by disabling recaptchas, and to address #44, we are adding a `Rack::Attack` initializer that will temporarily block IPs that send `GET` requests for `/favorites/:id/add-item`. This route returns a 404, requests made from a browser use `POST`.

(See https://github.com/boston-library/Commonwealth-public-interface/blob/master/config/initializers/rack_attack.rb for a similar implementation.)